### PR TITLE
refactor: replace crypto.randomUUID with uuidv4

### DIFF
--- a/fetch-client/fetched.ts
+++ b/fetch-client/fetched.ts
@@ -6,7 +6,6 @@ import { isUrnUuid, parseUrnUuid } from './urn-uuid.js'
 import type { UrnUuid } from './urn-uuid.js'
 import { createHttpSignatureAuthorization } from 'authorization-signature'
 import { ACTIVITYPUB_MEDIA_TYPE } from './activitypub.js'
-import { v4 as uuidv4 } from 'uuid'
 
 /**
  * async iterate the items in a remote Storage Collection via fetch
@@ -356,11 +355,12 @@ class SpaceFetched implements ISpace {
   //   }
   // }
   resource (resourcePathParam?: string, options: {
-    signer?: ISigner
+    signer?: ISigner,
+    uuid?: UrnUuid
   } = {}) {
     let resourcePath: `/${string}`
     if (typeof resourcePathParam === 'undefined') {
-      resourcePath = `/${uuidv4()}` as const
+      resourcePath = `/${options.uuid || crypto.randomUUID}` as const
     } else if (typeof resourcePathParam === 'string') {
       if (resourcePathParam.startsWith('/')) {
         resourcePath = resourcePathParam as `/${string}`
@@ -564,7 +564,7 @@ class StorageFetched implements IStorageClient {
       }
     } else if (typeof optionsOrId === 'object' || !optionsOrId) {
       options = {
-        id: optionsOrId?.id || `urn:uuid:${uuidv4()}`,
+        id: optionsOrId?.id || `urn:uuid:${crypto.randomUUID()}` as UrnUuid,
         ...optionsOrId
       }
     } else {

--- a/fetch-client/fetched.ts
+++ b/fetch-client/fetched.ts
@@ -6,6 +6,7 @@ import { isUrnUuid, parseUrnUuid } from './urn-uuid.js'
 import type { UrnUuid } from './urn-uuid.js'
 import { createHttpSignatureAuthorization } from 'authorization-signature'
 import { ACTIVITYPUB_MEDIA_TYPE } from './activitypub.js'
+import { v4 as uuidv4 } from 'uuid'
 
 /**
  * async iterate the items in a remote Storage Collection via fetch
@@ -359,7 +360,7 @@ class SpaceFetched implements ISpace {
   } = {}) {
     let resourcePath: `/${string}`
     if (typeof resourcePathParam === 'undefined') {
-      resourcePath = `/${crypto.randomUUID()}` as const
+      resourcePath = `/${uuidv4()}` as const
     } else if (typeof resourcePathParam === 'string') {
       if (resourcePathParam.startsWith('/')) {
         resourcePath = resourcePathParam as `/${string}`
@@ -563,7 +564,7 @@ class StorageFetched implements IStorageClient {
       }
     } else if (typeof optionsOrId === 'object' || !optionsOrId) {
       options = {
-        id: optionsOrId?.id || `urn:uuid:${crypto.randomUUID()}`,
+        id: optionsOrId?.id || `urn:uuid:${uuidv4()}`,
         ...optionsOrId
       }
     } else {

--- a/fetch-client/package.json
+++ b/fetch-client/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "authorization-signature": "^1.0.3",
+    "uuid": "^11.1.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/fetch-client/package.json
+++ b/fetch-client/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "authorization-signature": "^1.0.3",
-    "uuid": "^11.1.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/fetch-client/test-utils.ts
+++ b/fetch-client/test-utils.ts
@@ -3,6 +3,7 @@ import assert from "node:assert"
 import { IStorageClient } from "./types.js"
 import { isUrnUuid, parseUrnUuid } from "./urn-uuid.js"
 import { isValidActivityPubMediaType } from "./activitypub.js"
+import { v4 as uuidv4 } from "uuid"
 
 /**
  * perform generic testing on the provided pub
@@ -13,7 +14,7 @@ export async function testStorageClient(pub: IStorageClient) {
   const resource = space.resource()
 
   // store a message
-  const nonce = crypto.randomUUID()
+  const nonce = uuidv4()
   const message = new Blob([nonce],{type:'text/plain'})
   await resource.put(message)
 

--- a/fetch-client/test-utils.ts
+++ b/fetch-client/test-utils.ts
@@ -3,18 +3,17 @@ import assert from "node:assert"
 import { IStorageClient } from "./types.js"
 import { isUrnUuid, parseUrnUuid } from "./urn-uuid.js"
 import { isValidActivityPubMediaType } from "./activitypub.js"
-import { v4 as uuidv4 } from "uuid"
 
 /**
  * perform generic testing on the provided pub
  * @param pub - pub to test
  */
-export async function testStorageClient(pub: IStorageClient) {
+export async function testStorageClient(pub: IStorageClient, uuid?: string) {
   const space = pub.space()
   const resource = space.resource()
 
   // store a message
-  const nonce = uuidv4()
+  const nonce = uuid || crypto.randomUUID()
   const message = new Blob([nonce],{type:'text/plain'})
   await resource.put(message)
 

--- a/fetch-client/tests/testPubSetSpaceController.ts
+++ b/fetch-client/tests/testPubSetSpaceController.ts
@@ -11,6 +11,7 @@ import { getControllerOfDidKeyVerificationMethod } from "../did-key.js"
 import { fileURLToPath } from "url"
 import { StorageClient } from "../index.js"
 import assert from "assert"
+import { v4 as uuidv4 } from "uuid"
 
 /**
  * test a StorageClient to ensure it can update spaces
@@ -39,7 +40,7 @@ export default async function testSetSpaceController(
   */
    {
     // create space b
-    const spaceBUuid = crypto.randomUUID()
+    const spaceBUuid = uuidv4()
     const spaceBObject = {
       id: `urn:uuid:${spaceBUuid}` as UrnUuid,
     }

--- a/fetch-client/tests/testPubSetSpaceController.ts
+++ b/fetch-client/tests/testPubSetSpaceController.ts
@@ -11,7 +11,6 @@ import { getControllerOfDidKeyVerificationMethod } from "../did-key.js"
 import { fileURLToPath } from "url"
 import { StorageClient } from "../index.js"
 import assert from "assert"
-import { v4 as uuidv4 } from "uuid"
 
 /**
  * test a StorageClient to ensure it can update spaces
@@ -23,7 +22,8 @@ import { v4 as uuidv4 } from "uuid"
 export default async function testSetSpaceController(
   pub: IStorageClient,
   assert: typeof nodeAssert,
-  testing: Pick<typeof NodeTest,'test'>
+  testing: Pick<typeof NodeTest,'test'>,
+  uuid?: string,
 ) {
   const { test } = testing;
   await test('can put a resource with an http signature', async (t) => {
@@ -40,7 +40,7 @@ export default async function testSetSpaceController(
   */
    {
     // create space b
-    const spaceBUuid = uuidv4()
+    const spaceBUuid = uuid || crypto.randomUUID()
     const spaceBObject = {
       id: `urn:uuid:${spaceBUuid}` as UrnUuid,
     }

--- a/fetch-client/types.ts
+++ b/fetch-client/types.ts
@@ -74,7 +74,10 @@ interface Postable {
  */
 export interface ISpace extends Getable, Putable, Deletable {
   id: UrnUuid
-  resource: (path?: string) => IResourceInSpace
+  resource: (path?: string, options?: {
+    signer?: ISigner
+    uuid?: UrnUuid
+  }) => IResourceInSpace
 }
 
 /**

--- a/src/WalletStorage.ts
+++ b/src/WalletStorage.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 DID.coop. All rights reserved.
  */
 import { StorageClient } from '@wallet.storage/fetch-client'
-import { ISigner, ISpace } from '@wallet.storage/fetch-client/types'
+import { ISigner, ISpace, UrnUuid } from '@wallet.storage/fetch-client/types'
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class WalletStorage {
@@ -17,10 +17,10 @@ export class WalletStorage {
    * @param signer {ISigner} - Ed25519 did:key Signer.
    */
   static async provisionSpace (
-    { url, signer }: { url: string | URL, signer: ISigner }
+    { url, signer, id }: { url: string | URL, signer: ISigner, id?: UrnUuid }
   ): Promise<ISpace> {
     const storage = new StorageClient(new URL(url))
-    const space = storage.space({ signer })
+    const space = storage.space({ signer, id })
     // Create a new space (sends HTTP API call)
     await space.put()
     return space


### PR DESCRIPTION
This refactor replaces the usage of crypto.randomUUID() with the universally supported uuidv4() from the uuid package.

crypto.randomUUID() is not available in React Native, which causes runtime errors when the package is used in RN environments. By switching to uuidv4(), we ensure cross-platform compatibility without affecting existing behavior.

This change makes the package fully usable in React Native while keeping functionality identical for Node.js and web.